### PR TITLE
Add full failing command in output

### DIFF
--- a/lib/mix/tasks/git_hooks/run.ex
+++ b/lib/mix/tasks/git_hooks/run.ex
@@ -110,7 +110,7 @@ defmodule Mix.Tasks.GitHooks.Run do
   end
 
   defp run_task({:cmd, command, opts}, git_hook_type, git_hook_args) when is_list(opts) do
-    [command | args] = String.split(command, " ")
+    [base_command | args] = String.split(command, " ")
 
     env_vars = Keyword.get(opts, :env, [])
 
@@ -121,7 +121,7 @@ defmodule Mix.Tasks.GitHooks.Run do
         args
       end
 
-    command
+    base_command
     |> System.cmd(
       command_args,
       into: Config.io_stream(git_hook_type),
@@ -129,7 +129,7 @@ defmodule Mix.Tasks.GitHooks.Run do
     )
     |> case do
       {_result, 0} ->
-        Printer.success("`#{command} #{Enum.join(command_args, " ")}` was successful")
+        Printer.success("`#{command}` was successful")
 
       {result, _} ->
         if !Config.verbose?(git_hook_type), do: IO.puts(result)

--- a/test/mix/tasks/git_hooks/run_test.exs
+++ b/test/mix/tasks/git_hooks/run_test.exs
@@ -54,6 +54,16 @@ defmodule Mix.Tasks.RunTest do
 
       assert capture_io(fn -> Run.run(["pre-commit"]) end) =~ "`mix help clean` was successful"
     end
+
+    test "when verbose is enabled the command and args print in the error message" do
+      put_git_hook_config(:pre_commit,
+        tasks: [{:cmd, "false foo bar"}],
+        verbose: true
+      )
+
+      assert capture_io(fn -> catch_exit(Run.run(["pre-commit"])) end) =~
+               "pre_commit failed on `false foo bar`"
+    end
   end
 
   describe "Given args for the mix git hook task" do


### PR DESCRIPTION
This pull request changes output for failing tests to include the full command that failed instead of only the base command (e.g., "mix compile --warnings-as-errors" instead of "mix"). 

Previously, on test failure only the base command would be used in the message printed to stderr:

```
$ mix git_hooks.run pre_commit
↗ Running hooks for :pre_commit
✔ `mix clean` was successful
Compiling 14 files (.ex)
warning: variable "chunk" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/lunex.ex:51: Lunex.stream_upload/3
...
Compilation failed due to warnings while using the --warnings-as-errors option
× pre_commit failed on `mix`
** (exit) 1
   ...
```

Now, the full command is printed on failure:
```
$ mix git_hooks.run pre_commit
↗ Running hooks for :pre_commit
✔ `mix clean` was successful
Compiling 14 files (.ex)
warning: variable "chunk" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/lunex.ex:51: Lunex.stream_upload/3
...
Compilation failed due to warnings while using the --warnings-as-errors option
× pre_commit failed on `mix compile --warnings-as-errors`
** (exit) 1
    ...
```