### PR TITLE
Update README.MD - Example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ In `config/config.exs`
 
 ```elixir
 if Mix.env() != :prod do
+  use Mix.Config
+  
   config :git_hooks,
     auto_install: true,
     verbose: true,


### PR DESCRIPTION
Example configuration as is causes following CompileError in clean environment with git_hooks 0.5.0
** (CompileError) config/config.exs:2: undefined function config/2