### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 git_hooks-*.tar
 
+# Temporary files for e.g. tests.
+/tmp
+
 ## Stuff
 .elixir_ls/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Add to dependencies:
 
 ```elixir
 def deps do
-  [{:git_hooks, "~> 0.6.2", only: [:dev], runtime: false}]
+  [
+    {:git_hooks, "~> 0.6.2", only: [:dev], runtime: false}
+  ]
 end
 ```
 
@@ -251,3 +253,9 @@ It is also possible to run all the configured hooks:
 ```bash
 mix git_hooks.run all
 ```
+
+## Copyright and License
+
+Copyright (c) 2018 Adrián Quintás
+
+Source code is released under [the MIT license](./LICENSE).

--- a/lib/mix/tasks/git_hooks/install.ex
+++ b/lib/mix/tasks/git_hooks/install.ex
@@ -8,11 +8,14 @@ defmodule Mix.Tasks.GitHooks.Install do
   with the extension `.pre_git_hooks_backup`.
 
   ## Command line options
-    * `--quiet` - disables the output of the files that are beeing copied/backed up
+    * `--quiet` - disables the output of the files that are being copied/backed up
 
   To manually install the git hooks run:
 
-    `mix git_hooks.install`
+  ```elixir
+  mix git_hooks.install`
+  ```
+
   """
 
   use Mix.Task

--- a/lib/tasks/cmd.ex
+++ b/lib/tasks/cmd.ex
@@ -43,13 +43,14 @@ defmodule GitHooks.Tasks.Cmd do
   executing the file. You will need to check [which arguments are being sent by each git hook](https://git-scm.com/docs/githooks).
   * `env`: The environment variables that will be set in the execution context of the file.
 
-  ### Example
+  ### Examples
 
       iex> #{__MODULE__}.new({:cmd, "ls -l", env: [{"var", "test"}], include_hook_args: true}, :pre_commit, ["commit message"])
       %#{__MODULE__}{command: "ls", original_command: "ls -l", args: ["-l", "commit message"], env: [{"var", "test"}], git_hook_type: :pre_commit}
 
       iex> #{__MODULE__}.new({:cmd, "ls", include_hook_args: false}, :pre_commit, ["commit message"])
       %#{__MODULE__}{command: "ls", original_command: "ls", args: [], env: [], git_hook_type: :pre_commit}
+
   """
   @spec new(
           {:cmd, command :: String.t(), [any]},

--- a/lib/tasks/file.ex
+++ b/lib/tasks/file.ex
@@ -45,13 +45,14 @@ defmodule GitHooks.Tasks.File do
   executing the file. You will need to check [which arguments are being sent by each git hook](https://git-scm.com/docs/githooks).
   * `env`: The environment variables that will be set in the execution context of the file.
 
-  ### Example
+  ### Examples
 
       iex> #{__MODULE__}.new({:file, :test, env: [{"var", "test"}], include_hook_args: true}, :pre_commit, ["commit message"])
       %#{__MODULE__}{file_path: :test, args: ["commit message"], env: [{"var", "test"}], git_hook_type: :pre_commit}
 
       iex> #{__MODULE__}.new({:file, :test, include_hook_args: false}, :pre_commit, ["commit message"])
       %#{__MODULE__}{file_path: :test, args: [], env: [], git_hook_type: :pre_commit}
+
   """
   @spec new(
           {:file, path :: String.t(), [any]},

--- a/lib/tasks/mfa.ex
+++ b/lib/tasks/mfa.ex
@@ -36,10 +36,11 @@ defmodule GitHooks.Tasks.MFA do
   @doc """
   Creates a new `mfa` struct.
 
-  ### Example
+  ### Examples
 
       iex> #{__MODULE__}.new({MyModule, :my_function, 1}, :pre_commit, ["commit message"])
       %#{__MODULE__}{module: MyModule, function: :my_function, args: ["commit message"]}
+
   """
   @spec new(mfa(), GitHooks.git_hook_type(), GitHooks.git_hook_args()) :: __MODULE__.t()
   def new({module, function, arity}, git_hook_type, git_hook_args) do

--- a/lib/tasks/mix.ex
+++ b/lib/tasks/mix.ex
@@ -37,10 +37,11 @@ defmodule GitHooks.Tasks.Mix do
   This function expects a tuple or triple with `:mix_task`, the task name and
   the task args.
 
-  ### Example
+  ### Examples
 
       iex> #{__MODULE__}.new({:mix_task, :test, ["--failed"]})
       %#{__MODULE__}{task: :test, args: ["--failed"]}
+
   """
   @spec new({:mix_task, Mix.Task.task_name(), [any]} | Mix.Task.task_name()) :: __MODULE__.t()
   def new({:mix_task, task, args}) do
@@ -76,7 +77,7 @@ defimpl GitHooks.Task, for: GitHooks.Tasks.Mix do
 
   # Mix tasks always raise an error if they are not success, at the moment does
   # not seems that handling the result is needed. Also, handling the result to
-  # check the success of a task is almost imposible, as it will depend on each
+  # check the success of a task is almost impossible, as it will depend on each
   # implementation.
   #
   # XXX Since tests runs on the command, if they fail then this task is

--- a/mix.exs
+++ b/mix.exs
@@ -3,6 +3,7 @@ defmodule GitHooks.MixProject do
 
   use Mix.Project
 
+  @source_url "https://github.com/qgadrian/elixir_git_hooks"
   @version "0.6.2"
 
   def project do
@@ -12,17 +13,10 @@ defmodule GitHooks.MixProject do
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
-      package: package(),
-      description: description(),
-      docs: [
-        source_ref: "v#{@version}",
-        main: "readme",
-        extra_section: "README",
-        formatters: ["html", "epub"],
-        extras: extras()
-      ],
-      aliases: aliases(),
       deps: deps(),
+      package: package(),
+      docs: docs(),
+      aliases: aliases(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
         coveralls: :test,
@@ -46,15 +40,14 @@ defmodule GitHooks.MixProject do
   defp package do
     [
       name: "git_hooks",
-      files: ["lib", "priv", "mix.exs", "README*"],
+      description: "Add git hooks to your Elixir projects",
+      files: ["lib", "priv", "mix.exs", "README*", "LICENSE*", "CODE_OF_CONDUCT*"],
       maintainers: ["Adrián Quintás"],
       licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/qgadrian/elixir_git_hooks"}
+      links: %{
+        "GitHub" => @source_url
+      }
     ]
-  end
-
-  defp description do
-    "Add git hooks to your Elixir projects"
   end
 
   defp deps do
@@ -62,7 +55,7 @@ defmodule GitHooks.MixProject do
       {:blankable, "~> 1.0.0"},
       {:credo, "~> 1.5.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.1.0", only: [:dev], runtime: false},
-      {:ex_doc, "~> 0.21", only: :dev, runtime: false},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:excoveralls, "~> 0.10", only: :test},
       {:inch_ex, ">= 0.0.0", only: :docs},
       {:recase, "~> 0.7.0"}
@@ -77,9 +70,17 @@ defmodule GitHooks.MixProject do
     ]
   end
 
-  defp extras do
+  defp docs do
     [
-      "README.md"
+      extras: [
+        {:"CODE_OF_CONDUCT.md", [title: "Code of Conduct"]},
+        {:LICENSE, [title: "License"]},
+        "README.md"
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the main reference doc for this
Elixir library which leverage on latest features of ExDoc.