### PR TITLE
Add option to set a mix executable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,6 @@ mix git_hooks.run all
 
 ## Copyright and License
 
-Copyright (c) 2018 Adrián Quintás
+Copyright (c) 2021 Adrián Quintás
 
 Source code is released under [the MIT license](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Main features are:
   * [Automatic installation](#automatic-installation)
   * [Manual installation](#manual-installation)
 * [Configuration](#configuration)
-  * [Disable auto install](#disable-auto-install)
+  * [Mix path](#mix-path)
+  * [Auto install](#auto-install)
+  * [Hook configuration](#hook-configuration)
   * [Example config](#example-config)
   * [Type of tasks](#type-of-tasks)
     * [Mix task](#mix-task)
@@ -40,6 +42,7 @@ Main features are:
 * [Execution](#execution)
   * [Automatic execution](#automatic-execution)
   * [Manual execution](#manual-execution)
+* [Copyright and License](#copyright-and-license)
 
 <!-- vim-markdown-toc -->
 
@@ -85,6 +88,25 @@ mix git_hooks.install
 
 ## Configuration
 
+### Mix path
+
+This library expects `elixir` to be installed in your system and the `mix` binary to be available. If you want to provide an specific path to run the `mix` executable, it can be done using the `mix_path` configuration.
+
+The following example would run the hooks on a docker container:
+
+```elixir
+config :git_hooks,
+  auto_install: false,
+  mix_path: "docker-compose exec mix",
+```
+
+### Auto install
+
+To disable the automatic install of the git hooks set the configuration key `auto_install` to
+`false`.
+
+### Hook configuration
+
 One or more git hooks can be configured, those hooks will be the ones
 [installed](#installation) in your git project.
 
@@ -92,11 +114,6 @@ Currently there are supported two configuration options:
 
   * **tasks**: A list of the commands that will be executed when running a git hook. [See types of tasks](#type-of-tasks) for more info.
   * **verbose**: If true, the output of the mix tasks will be visible. This can be configured globally or per git hook.
-
-### Disable auto install
-
-To disable the automatic install of the git hooks set the configuration key `auto_install` to
-`false`.
 
 ### Example config
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Main features are:
   * [Manual installation](#manual-installation)
 * [Configuration](#configuration)
   * [Mix path](#mix-path)
+    * [Troubleshooting in docker containers](#troubleshooting-in-docker-containers)
   * [Auto install](#auto-install)
   * [Hook configuration](#hook-configuration)
   * [Example config](#example-config)
@@ -99,6 +100,11 @@ config :git_hooks,
   auto_install: false,
   mix_path: "docker-compose exec mix",
 ```
+
+#### Troubleshooting in docker containers
+
+The `mix_path` configuration can be use to run mix hooks on a Docker container.
+If you have a TTY error running mix in a Docker container use `docker exec --tty $(docker-compose ps -q web) mix` as the `mix_path`. See this [issue](https://github.com/qgadrian/elixir_git_hooks/issues/82) as reference.
 
 ### Auto install
 

--- a/lib/config/config.ex
+++ b/lib/config/config.ex
@@ -61,6 +61,17 @@ defmodule GitHooks.Config do
   end
 
   @doc """
+  Returns the configured mix path.
+
+  The config should be a valid path the `mix` binary. The default behaviour
+  expects a regular `elixir` install and defaults to `mix`.
+  """
+  @spec mix_path() :: String.t()
+  def mix_path do
+    Application.get_env(:git_hooks, :mix_path, "mix")
+  end
+
+  @doc """
   Returns the general verbose configuration.
   """
   @spec verbose?() :: boolean()

--- a/lib/mix/tasks/git_hooks/install.ex
+++ b/lib/mix/tasks/git_hooks/install.ex
@@ -42,6 +42,8 @@ defmodule Mix.Tasks.GitHooks.Install do
 
     Printer.info("Installing git hooks...")
 
+    mix_path = Config.mix_path()
+
     ensure_hooks_folder_exists()
     clean_missing_hooks()
     track_configured_hooks()
@@ -58,7 +60,9 @@ defmodule Mix.Tasks.GitHooks.Install do
             |> Path.join("/../.git/hooks/#{git_hook_atom_as_kebab_string}")
 
           target_file_body =
-            String.replace(body, "$git_hook", git_hook_atom_as_string, global: true)
+            body
+            |> String.replace("$git_hook", git_hook_atom_as_string)
+            |> String.replace("$mix_path", mix_path)
 
           unless opts[:quiet] || !Config.verbose?() do
             Printer.info(

--- a/priv/hook_template
+++ b/priv/hook_template
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-mix git_hooks.run $git_hook "$@"
+$mix_path git_hooks.run $git_hook "$@"
 [ $? -ne 0 ] && exit 1
 exit 0
 fi


### PR DESCRIPTION
Request from #82

Use the following config to override the default `mix` executable path:

```elixir
config :git_hooks,
  mix_path: "docker-compose exec mix",
# ...
```