### PR TITLE
Configurability to run hooks only on a certain branch

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,13 +2,6 @@ use Mix.Config
 
 config :git_hooks,
   auto_install: false,
-  current_branch_fn: fn ->
-    if Mix.env() == :test do
-      {"master\n", 0}
-    else
-      System.cmd("git", ["branch", "--show-current"])
-    end
-  end,
   hooks: [
     # prepare_commit_msg: [
     # verbose: true,
@@ -39,3 +32,7 @@ config :git_hooks,
       ]
     ]
   ]
+
+if Mix.env() == :test do
+  config :git_hooks, current_branch_fn: fn -> {"master\n", 0} end
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,13 @@ use Mix.Config
 
 config :git_hooks,
   auto_install: false,
+  current_branch_fn: fn ->
+    if Mix.env() == :test do
+      {"master\n", 0}
+    else
+      System.cmd("git", ["branch", "--show-current"])
+    end
+  end,
   hooks: [
     # prepare_commit_msg: [
     # verbose: true,

--- a/lib/config/config.ex
+++ b/lib/config/config.ex
@@ -123,16 +123,20 @@ defmodule GitHooks.Config do
     |> String.replace("\n", "")
   end
 
+  @empty_branches [whitelist: [], blacklist: []]
   @spec branches() :: Keyword.t()
   defp branches do
-    Keyword.merge([whitelist: [], blacklist: []], Application.get_env(:git_hooks, :branches, []))
+    Keyword.merge(@empty_branches, Application.get_env(:git_hooks, :branches, []))
   end
 
   @spec branches(atom) :: Keyword.t()
   defp branches(git_hook_type) do
-    git_hook_type
-    |> get_git_hook_type_config()
-    |> Keyword.get_lazy(:branches, fn -> branches() end)
+    branches_config =
+      git_hook_type
+      |> get_git_hook_type_config()
+      |> Keyword.get_lazy(:branches, fn -> branches() end)
+
+    Keyword.merge(@empty_branches, branches_config)
   end
 
   defp get_git_hook_type_config(git_hook_type) do

--- a/lib/config/config.ex
+++ b/lib/config/config.ex
@@ -112,7 +112,12 @@ defmodule GitHooks.Config do
   """
   @spec current_branch() :: String.t()
   def current_branch do
-    Application.get_env(:git_hooks, :current_branch_fn).()
+    current_branch_fn =
+      Application.get_env(:git_hooks, :current_branch_fn, fn ->
+        System.cmd("git", ["branch", "--show-current"])
+      end)
+
+    current_branch_fn.()
     |> Tuple.to_list()
     |> List.first()
     |> String.replace("\n", "")

--- a/lib/mix/tasks/git_hooks/run.ex
+++ b/lib/mix/tasks/git_hooks/run.ex
@@ -53,12 +53,19 @@ defmodule Mix.Tasks.GitHooks.Run do
   def run(args) do
     {[git_hook_name], args} = Enum.split(args, 1)
 
-    git_hook_name
-    |> get_atom_from_arg()
-    |> check_is_valid_git_hook!()
-    |> Printer.info("Running hooks for ", append_first_arg: true)
-    |> Config.tasks()
-    |> run_tasks(args)
+    git_hook_type =
+      git_hook_name
+      |> get_atom_from_arg()
+      |> check_is_valid_git_hook!()
+
+    if Config.current_branch_allowed?(git_hook_type) do
+      git_hook_type
+      |> Printer.info("Running hooks for ", append_first_arg: true)
+      |> Config.tasks()
+      |> run_tasks(args)
+    else
+      Printer.info("skipping git_hooks for #{Config.current_branch()} branch")
+    end
   end
 
   @spec run_tasks({atom, list(GitHooks.allowed_configs())}, GitHooks.git_hook_args()) ::

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -27,6 +27,26 @@ defmodule GitHooks.ConfigTest do
       assert Config.tasks(:pre_commit) == {:pre_commit, tasks}
     end
 
+    test "when current branch is allowed to run for the git hook then current_branch_allowed? function returns true" do
+      branches_config = [whitelist: ["master"], blacklist: []]
+
+      put_git_hook_config(:pre_commit, branches: branches_config)
+
+      assert Config.current_branch_allowed?(:pre_commit)
+    end
+
+    test "when branches config is not provided then current_branch_allowed? function return true" do
+      assert Config.current_branch_allowed?(:pre_commit)
+    end
+
+    test "when current branch is disallowed to run git hook then current_branch_allowed? function returns false" do
+      branches_config = [whitelist: [], blacklist: ["master"]]
+
+      put_git_hook_config(:pre_commit, branches: branches_config)
+
+      refute Config.current_branch_allowed?(:pre_commit)
+    end
+
     test "when the verbose is enabled for the git hook then the verbose config function returns true" do
       put_git_hook_config(:pre_commit, verbose: true)
 

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -28,6 +28,7 @@ defmodule GitHooks.ConfigTest do
     end
 
     test "when current branch is allowed to run for the git hook then current_branch_allowed? function returns true" do
+      Application.put_env(:git_hooks, :current_branch_fn, fn -> {"master\n", 0} end)
       branches_config = [whitelist: ["master"], blacklist: []]
 
       put_git_hook_config(:pre_commit, branches: branches_config)
@@ -40,11 +41,27 @@ defmodule GitHooks.ConfigTest do
     end
 
     test "when current branch is disallowed to run git hook then current_branch_allowed? function returns false" do
+      Application.put_env(:git_hooks, :current_branch_fn, fn -> {"master\n", 0} end)
       branches_config = [whitelist: [], blacklist: ["master"]]
 
       put_git_hook_config(:pre_commit, branches: branches_config)
 
       refute Config.current_branch_allowed?(:pre_commit)
+    end
+
+    test "when current branch match regex built from branches config then current_branch_allowed? function returns true" do
+      branches_config = [whitelist: ["master", "main", "featprefix-.*"], blacklist: ["wip-.*"]]
+
+      put_git_hook_config(:pre_commit, branches: branches_config)
+
+      Application.put_env(:git_hooks, :current_branch_fn, fn -> {"featprefix-123\n", 0} end)
+      assert Config.current_branch_allowed?(:pre_commit)
+
+      Application.put_env(:git_hooks, :current_branch_fn, fn -> {"wip-123\n", 0} end)
+      refute Config.current_branch_allowed?(:pre_commit)
+
+      Application.put_env(:git_hooks, :current_branch_fn, fn -> {"branch-not-on-lists\n", 0} end)
+      assert Config.current_branch_allowed?(:pre_commit)
     end
 
     test "when the verbose is enabled for the git hook then the verbose config function returns true" do

--- a/test/mix/tasks/git_hooks/run_test.exs
+++ b/test/mix/tasks/git_hooks/run_test.exs
@@ -83,6 +83,17 @@ defmodule Mix.Tasks.RunTest do
       assert capture_io(fn -> catch_exit(Run.run(["pre-commit"])) end) =~
                "`pre_commit`: `false foo bar` execution failed"
     end
+
+    test "when current branch is not allowed to run git hooks" do
+      put_git_hook_config(:pre_commit,
+        tasks: [{:cmd, "echo 'test command'"}],
+        verbose: true,
+        branches: [whitelist: [], blacklist: ["master"]]
+      )
+
+      assert capture_io(fn -> Run.run(["pre-commit"]) end) =~
+               "skipping git_hooks for master branch"
+    end
   end
 
   describe "Given args for the mix git hook task" do
@@ -126,6 +137,17 @@ defmodule Mix.Tasks.RunTest do
         end
       end)
     end
+
+    test "when current branch is not allowed to run git hooks" do
+      put_git_hook_config(:pre_commit,
+        tasks: [{:mix_task, :help, ["test"]}],
+        verbose: true,
+        branches: [whitelist: [], blacklist: ["master"]]
+      )
+
+      assert capture_io(fn -> Run.run(["pre-commit"]) end) =~
+               "skipping git_hooks for master branch"
+    end
   end
 
   describe "Given env vars to the mix git hook task" do
@@ -163,6 +185,19 @@ defmodule Mix.Tasks.RunTest do
         # Run.run(["pre-commit"])
         assert catch_exit(Run.run(["pre-commit"])) == {:shutdown, 1}
       end) =~ "Failed"
+    end
+
+    test "when current branch is not allowed to run git hooks" do
+      env = [{"TEST", "test-value"}]
+
+      put_git_hook_config(:pre_commit,
+        tasks: [{:cmd, "env", env: env}],
+        verbose: true,
+        branches: [whitelist: [], blacklist: ["master"]]
+      )
+
+      assert capture_io(fn -> Run.run(["pre-commit"]) end) =~
+               "skipping git_hooks for master branch"
     end
   end
 end

--- a/test/support/config_case.ex
+++ b/test/support/config_case.ex
@@ -7,6 +7,7 @@ defmodule GitHooks.TestSupport.ConfigCase do
 
   using do
     quote do
+      @default_branches [whitelist: [], blacklist: []]
       @default_verbose false
       @default_mix_tasks ["mix help", "mix help deps"]
 
@@ -27,6 +28,7 @@ defmodule GitHooks.TestSupport.ConfigCase do
 
       def put_git_hook_config(git_hook_types, opts) when is_list(git_hook_types) do
         git_hook_config = [
+          branches: opts[:branches] || @default_branches,
           verbose: opts[:verbose] || @default_verbose,
           tasks: opts[:tasks] || @default_mix_tasks
         ]
@@ -41,6 +43,7 @@ defmodule GitHooks.TestSupport.ConfigCase do
 
       def put_git_hook_config(git_hook_type, opts) do
         git_hook_config = [
+          branches: opts[:branches] || @default_branches,
           verbose: opts[:verbose] || @default_verbose,
           tasks: opts[:tasks] || @default_mix_tasks
         ]


### PR DESCRIPTION
### Updated

Closes #84

This PR adds the option to run hooks only on a certain branch by adding a new global and git hook type config called `branches`, that can be configured like below:

```elixir
config :git_hooks, branches: [whitelist: ["master", "main", "featprefix-.*"], blacklist: ["wip-.*"]]
```

or

```elixir
config :git_hooks,
  hooks: [
    pre_commit: [
      branches: [whitelist: ["master", "main", "featprefix-.*"], blacklist: ["wip-.*"]
    ]
  ]
```

You can set only whitelist or blacklist as well:

```elixir
config :git_hooks,
  hooks: [
    pre_commit: [
      branches: [blacklist: ["wip-.*"]]
    ]
  ]
```

Also, this option is completely optional, so if it is not provided, all the branches will be able to execute git_hooks commands.