### PR TITLE
Update install task to resolve git submodule directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ config :git_hooks,
   mix_path: "docker-compose exec mix",
 ```
 
+### Git path
+
+This library expects `git` to be installed in the `.git` directory relative to your project root, or when using git submodules, the root of the superproject. If you want to provide a specific path to a custom git directory, it can be done using the `git_path` configuration.
+
+The follow example would run the hooks within a git submodule:
+
+```elixir
+config :git_hooks,
+  git_path: "../.git/modules/submodule-repo"
+```
+
 #### Troubleshooting in docker containers
 
 The `mix_path` configuration can be use to run mix hooks on a Docker container.

--- a/lib/mix/tasks/git_hooks/install.ex
+++ b/lib/mix/tasks/git_hooks/install.ex
@@ -123,12 +123,20 @@ defmodule Mix.Tasks.GitHooks.Install do
 
   @spec resolve_git_path() :: any
   defp resolve_git_path() do
-    git_path = Path.join(Project.deps_path(), "/../.git")
+    :git_hooks
+    |> Application.get_env(:git_path)
+    |> case do
+      nil ->
+        path = Path.join(Project.deps_path(), "/../.git")
 
-    if File.dir?(git_path) do
-      git_path
-    else
-      resolve_git_submodule_path(git_path)
+        if File.dir?(path) do
+          path
+        else
+          resolve_git_submodule_path(path)
+        end
+
+      custom_path ->
+        custom_path
     end
   end
 


### PR DESCRIPTION
I was attempting to use this package in a project that uses git-submodules and noticed it didn't have submodule support. This PR updates the `install.ex` task to consolidate how it finds the `.git` directory and also adds submodule resolution support.

I've tested this locally against a standalone repo as well as a repo included as a git submodule.

If this PR is welcome, please let me know if there is anything else you need included.


**Standalone repo output**
```
❯ mix git_hooks.install

↗ Installing git hooks...
↗ Writing git hook for `pre_commit` to `/Users/wenzel/standalone-repo/deps/../.git/hooks/pre-commit`
↗ Backing up git hook file `/Users/wenzel/standalone-repo/deps/../.git/hooks/pre-commit` to `/Users/wenzel/standalone-repo/deps/../.git/hooks/pre-commit.pre_git_hooks_backup`
```

**Submodule repo output**
```
❯ mix git_hooks.install

↗ Installing git hooks...
↗ Writing git hook for `pre_commit` to `/Users/wenzel/parent-repo/submodule-repo/deps/../../.git/modules/submodule-repo/hooks/pre-commit`
↗ Backing up git hook file `/Users/wenzel/parent-repo/submodule-repo/deps/../../.git/modules/submodule-repo/hooks/pre-commit` to `/Users/wenzel/parent-repo/submodule-repo/deps/../../.git/modules/submodule-repo/hooks/pre-commit.pre_git_hooks_backup`
```