### PR TITLE
Use git to find .git or fall back to old behavior

### DIFF
--- a/lib/git.ex
+++ b/lib/git.ex
@@ -5,25 +5,59 @@ defmodule GitHooks.Git do
 
   @doc false
   @spec resolve_git_path() :: any
-  def resolve_git_path do
-    :git_hooks
-    |> Application.get_env(:git_path)
-    |> case do
-      nil ->
-        path = Path.join(Project.deps_path(), "/../.git")
+  def resolve_git_path,
+    do: maybe_preconfigured(Application.get_env(:git_hooks, :git_path, :detect))
 
-        if File.dir?(path) do
-          path
-        else
-          resolve_git_submodule_path(path)
-        end
+  @spec maybe_preconfigured(:detect | binary) :: Path.t() | no_return
+  def maybe_preconfigured(:detect) do
+    # if we can't figure out cwd, we can't do anything
+    working_directory = working_dir(File.cwd!())
 
-      custom_path ->
-        custom_path
+    case path_from_git(working_directory) do
+      {:ok, path} ->
+        path
+
+      {:error, :no_system_git} ->
+        use_legacy_configuration()
     end
   end
 
-  @spec resolve_git_submodule_path(String.t()) :: any
+  def maybe_preconfigured(path) do
+    if File.exists?(path) do
+      path
+    else
+      # should this warn and try to detect?
+      raise "failed to find #{path}"
+    end
+  end
+
+  @spec use_legacy_configuration :: Path.t() | no_return
+  def use_legacy_configuration do
+    path = Path.join(Project.deps_path(), "/../.git")
+
+    maybe_submodules(File.dir?(path), path)
+  end
+
+  @spec path_from_git(Path.t(), String.t()) :: {:ok, Path.t()} | {:error, :no_system_git}
+  def path_from_git(wd, git \\ "git") do
+    case System.find_executable(git) &&
+           System.cmd(git, ["rev-parse", "--show-toplevel"], cd: wd) do
+      {output, 0} ->
+        # We assume git is correct about this path
+        {:ok, Path.join(String.trim(output), ".git")}
+
+      _ ->
+        {:error, :no_system_git}
+    end
+  end
+
+  defp maybe_submodules(true, path), do: resolve_git_submodule_path(path)
+
+  defp maybe_submodules(false, path), do: path
+
+  defp parent_basename(path), do: Path.basename(Path.dirname(path))
+
+  @spec resolve_git_submodule_path(String.t()) :: Path.t() | no_return
   defp resolve_git_submodule_path(git_path) do
     with {:ok, contents} <- File.read(git_path),
          %{"dir" => submodule_dir} <- Regex.named_captures(~r/^gitdir:\s+(?<dir>.*)$/, contents) do
@@ -32,6 +66,14 @@ defmodule GitHooks.Git do
     else
       _error ->
         raise "Error resolving git submodule path '#{git_path}'"
+    end
+  end
+
+  defp working_dir(path) do
+    if parent_basename(path) == "deps" do
+      Path.dirname(path)
+    else
+      path
     end
   end
 end

--- a/lib/git.ex
+++ b/lib/git.ex
@@ -8,6 +8,12 @@ defmodule GitHooks.Git do
   def resolve_git_path,
     do: maybe_preconfigured(Application.get_env(:git_hooks, :git_path, :detect))
 
+  def resolve_app_path do
+    git_dir = maybe_preconfigured(Application.get_env(:git_hooks, :git_path, :detect))
+    repo_dir = Path.dirname(git_dir)
+    Path.relative_to(File.cwd!(), repo_dir)
+  end
+
   @spec maybe_preconfigured(:detect | binary) :: Path.t() | no_return
   def maybe_preconfigured(:detect) do
     # if we can't figure out cwd, we can't do anything

--- a/lib/mix/tasks/git_hooks/install.ex
+++ b/lib/mix/tasks/git_hooks/install.ex
@@ -105,7 +105,7 @@ defmodule Mix.Tasks.GitHooks.Install do
     git_hooks = Config.git_hooks() |> Enum.join(" ")
 
     Git.resolve_git_path()
-    |> Path.join("/hooks/git_hooks.db")
+    |> Path.join("/git_hooks.db")
     |> write_backup(git_hooks)
   end
 

--- a/lib/mix/tasks/git_hooks/install.ex
+++ b/lib/mix/tasks/git_hooks/install.ex
@@ -43,6 +43,7 @@ defmodule Mix.Tasks.GitHooks.Install do
     Printer.info("Installing git hooks...")
 
     mix_path = Config.mix_path()
+    project_path = GitHooks.Git.resolve_app_path()
 
     ensure_hooks_folder_exists()
     clean_missing_hooks()
@@ -63,6 +64,7 @@ defmodule Mix.Tasks.GitHooks.Install do
             body
             |> String.replace("$git_hook", git_hook_atom_as_string)
             |> String.replace("$mix_path", mix_path)
+            |> String.replace("$project_path", project_path)
 
           unless opts[:quiet] || !Config.verbose?() do
             Printer.info(

--- a/priv/hook_template
+++ b/priv/hook_template
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+[ "$project_path" != "" ] && cd $project_path
+
 $mix_path git_hooks.run $git_hook "$@"
 [ $? -ne 0 ] && exit 1
 exit 0

--- a/test/config/path_test.exs
+++ b/test/config/path_test.exs
@@ -1,0 +1,52 @@
+defmodule GitHooks.PathTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: false
+  use GitHooks.TestSupport.ConfigCase
+
+  alias GitHooks.Git
+
+  describe "Given a git hook type" do
+    @tag :tmp_dir
+    test "when inside a normal git repo at toplevel", %{tmp_dir: tmp_dir} do
+      copy_fake_git_dir(tmp_dir)
+      assert Git.path_from_git(tmp_dir) == {:ok, Path.join(tmp_dir, ".git")}
+    end
+
+    @tag :tmp_dir
+    test "when inside a normal git repo with git-hooks cloned in deps folder", %{tmp_dir: tmp_dir} do
+      dep_dir = Path.join([tmp_dir, "deps", "git-hooks"])
+      File.mkdir_p!(dep_dir)
+      copy_fake_git_dir(tmp_dir)
+      copy_fake_git_dir(dep_dir)
+      assert Git.path_from_git(tmp_dir) == {:ok, Path.join(tmp_dir, ".git")}
+    end
+
+    @tag :tmp_dir
+    test "when inside a git repo where the elixir project is not the root", %{tmp_dir: tmp_dir} do
+      all_levels = increasing_levels(tmp_dir)
+
+      for {top_name, deep_dir} <- all_levels do
+        assert Git.path_from_git(deep_dir) == {:ok, Path.join([tmp_dir, top_name, ".git"])}
+      end
+    end
+  end
+
+  # generates a list of directories, each one one level deeper than the previous one
+  defp increasing_levels(path) do
+    for i <- ?a..?c, into: [] do
+      top_basename = to_string(i)
+      top_directory = Path.join([path, top_basename])
+      paths = Enum.map(?a..i, fn n -> to_string([n]) end)
+      final_dir = Path.join([top_directory] ++ paths)
+      File.mkdir_p!(final_dir)
+      copy_fake_git_dir(top_directory)
+      {top_basename, final_dir}
+    end
+  end
+
+  defp copy_fake_git_dir(path) do
+    git_dir = Path.join([path, ".git"])
+    File.cp_r!(Path.join(File.cwd!(), "test/fixtures/fake_git_dir"), git_dir)
+  end
+end

--- a/test/config/path_test.exs
+++ b/test/config/path_test.exs
@@ -30,6 +30,17 @@ defmodule GitHooks.PathTest do
         assert Git.path_from_git(deep_dir) == {:ok, Path.join([tmp_dir, top_name, ".git"])}
       end
     end
+
+    @tag :tmp_dir
+    test "when git is not installed", %{tmp_dir: tmp_dir} do
+      assert Git.path_from_git(tmp_dir, "fakegit") == {:error, :no_system_git}
+      path = Path.join([Mix.Project.deps_path(), "..", ".git"])
+      message = "Error resolving git submodule path '#{path}'"
+
+      assert_raise RuntimeError, fn ->
+        Git.use_legacy_configuration()
+      end
+    end
   end
 
   # generates a list of directories, each one one level deeper than the previous one

--- a/test/fixtures/fake_git_dir/HEAD
+++ b/test/fixtures/fake_git_dir/HEAD
@@ -1,0 +1,1 @@
+ref: refs/heads/main

--- a/test/fixtures/fake_git_dir/config
+++ b/test/fixtures/fake_git_dir/config
@@ -1,0 +1,7 @@
+[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	ignorecase = true
+	precomposeunicode = true

--- a/test/fixtures/fake_git_dir/description
+++ b/test/fixtures/fake_git_dir/description
@@ -1,0 +1,1 @@
+Unnamed repository; edit this file 'description' to name the repository.

--- a/test/fixtures/fake_git_dir/info/exclude
+++ b/test/fixtures/fake_git_dir/info/exclude
@@ -1,0 +1,6 @@
+# git ls-files --others --exclude-from=.git/info/exclude
+# Lines that start with '#' are comments.
+# For a project mostly in C, the following would be a good set of
+# exclude patterns (uncomment them if you want to use them):
+# *.[oa]
+# *~


### PR DESCRIPTION
This should fix finding git directories that are above the current directory, as well as deal with nonstandard git folders, etc.

Improvements needed to merge this PR:
- [x] call out to git
- [x] validate git_path config option
- [x] update hook to run mix in the project root
- [x] test git path detection
- [x] test legacy path generation 

Algorithm:

    Try app env

    if :detect or empty, go to detection
    if exists, return path
    if error, error or warn and raise

    Detection

    If File.cwd!() does not work, give up
    If parent path is deps, go up one level
    If git exists, use its output without verification
    If git does not exist, use fallback
    If fallback is not right, use submodule


This greatly reduces the chance of failure when git would just do the right thing. The `git_path` config is not enough for a lot of cases, like when providing an absolute path is not feasible and different people have their git checkouts configured differently.