### PR TITLE
Allow setting up a custom project path

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Main features:
   * [Auto install](#auto-install)
   * [Hook configuration](#hook-configuration)
   * [Git submodules](#git-submodules)
+  * [Custom project path](#custom-project-path)
   * [Custom mix path](#custom-mix-path)
       * [Troubleshooting in docker containers](#troubleshooting-in-docker-containers)
   * [Example config](#example-config)
@@ -117,6 +118,29 @@ Setting a custom _git hooks_ config path is also supported:
 
 ```
 git config core.hooksPath .myCustomGithooks/
+```
+
+### Custom project path
+
+This library assumes a simple Elixir project architecture. This is, an Elixir
+project in the root of a git repository.
+
+If you have a different project architecture, you can specify the absolute path
+of your project using the `project_path` configuration:
+
+```elixir
+{project_path, 0} = System.cmd("pwd", [])
+project_path = String.replace(project_path, ~r/\n/, "/")
+
+config :git_hooks,
+  hooks: [
+    pre_commit: [
+      tasks: [
+        {:cmd, "mix format --check-formatted"}
+      ]
+    ]
+  ],
+  project_path: project_path
 ```
 
 ### Custom mix path

--- a/lib/git/path.ex
+++ b/lib/git/path.ex
@@ -15,7 +15,9 @@ defmodule GitHooks.Git.Path do
       resolve_git_path_based_on_git_version()
       |> Path.dirname()
 
-    Path.relative_to(File.cwd!(), repo_path)
+    project_path = Application.get_env(:git_hooks, :project_path, File.cwd!())
+
+    Path.relative_to(project_path, repo_path)
   end
 
   @spec git_hooks_path_for(path :: String.t()) :: String.t()

--- a/lib/git/path.ex
+++ b/lib/git/path.ex
@@ -3,10 +3,19 @@ defmodule GitHooks.Git.Path do
 
   alias GitHooks.Git
 
-  @doc false
+  @doc """
+  Returns the absolute `.git` path directory for the parent project.
+  """
   @spec resolve_git_hooks_path() :: any
   def resolve_git_hooks_path do
-    resolve_git_path_based_on_git_version("hooks")
+    path_for =
+      "hooks"
+      |> resolve_git_path_based_on_git_version()
+      |> Path.relative_to(resolve_app_path())
+
+    resolve_app_path()
+    |> Path.join(path_for)
+    |> String.replace(~r/\/+/, "/")
   end
 
   @doc false
@@ -20,6 +29,10 @@ defmodule GitHooks.Git.Path do
     Path.relative_to(project_path, repo_path)
   end
 
+  @doc """
+  Returns the absolute `.git` path directory for the parent project, appending
+  the given path.
+  """
   @spec git_hooks_path_for(path :: String.t()) :: String.t()
   def git_hooks_path_for(path) do
     __MODULE__.resolve_git_hooks_path()

--- a/lib/mix/tasks/git_hooks/install.ex
+++ b/lib/mix/tasks/git_hooks/install.ex
@@ -62,6 +62,10 @@ defmodule Mix.Tasks.GitHooks.Install do
           {:ok, body} ->
             target_file_path = GitPath.git_hooks_path_for(git_hook_atom_as_kebab_string)
 
+            unless opts[:quiet] || !Config.verbose?() do
+              Printer.info("Installed git hook: #{target_file_path}")
+            end
+
             target_file_body =
               body
               |> String.replace("$git_hook", git_hook_atom_as_string)

--- a/test/git/path_test.exs
+++ b/test/git/path_test.exs
@@ -4,14 +4,29 @@ defmodule GitHooks.Git.PathTest do
   alias GitHooks.Git.Path
 
   describe "git_hooks_path_for/1" do
-    test "appends the path to the hooks folder" do
-      assert Path.git_hooks_path_for("/testing") == ".git/hooks/testing"
+    setup [:project_path]
+
+    test "appends the path to the `.git/hooks` folder", %{project_path: project_path} do
+      assert Path.git_hooks_path_for("/testing") == "#{project_path}/.git/hooks/testing"
     end
   end
 
   describe "resolve_git_hooks_path/0" do
-    test "returns the git path of the project" do
-      assert Path.resolve_git_hooks_path() == ".git/hooks"
+    setup [:project_path]
+
+    test "returns the git path of the project", %{project_path: project_path} do
+      assert Path.resolve_git_hooks_path() == "#{project_path}/.git/hooks"
     end
+  end
+
+  #
+  # Private functions
+  #
+
+  defp project_path(_) do
+    {project_path, 0} = System.cmd("pwd", [])
+    project_path = String.replace(project_path, ~r/\n/, "")
+
+    {:ok, %{project_path: project_path}}
   end
 end


### PR DESCRIPTION
This will add flexibility when the dependency it's placed in a external
path outside the original repository