### PR TITLE
feat: Makes MFA more flexible by receiving args as array

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ hook.
 
 Just add in your config the
 [MFA](https://hexdocs.pm/elixir/typespecs.html#built-in-types) (`{module,
-function, arity}`) definition:
+function}`) definition:
 
 ```elixir
 config :git_hooks,
@@ -309,15 +309,11 @@ config :git_hooks,
   hooks: [
     commit_msg: [
       tasks: [
-        {MyModule, :execute, 2}
+        {MyModule, :execute}
       ]
     ]
   ]
 ```
-
-To check how many args you function should expect [check the git
-documentation](https://git-scm.com/docs/githooks) to know which parameters are
-being sent on each hook.
 
 ## Removing a hook
 

--- a/lib/git_hooks.ex
+++ b/lib/git_hooks.ex
@@ -29,6 +29,7 @@ defmodule GitHooks do
           | {:mix_task, Mix.Task.task_name()}
           | {:mix_task, Mix.Task.task_name(), [any]}
           | mfa()
+          | {module(), atom()}
 
   @spec new_task(allowed_configs(), git_hook_type(), git_hook_args()) ::
           GitHooks.Task.t() | no_return
@@ -54,6 +55,10 @@ defmodule GitHooks do
 
   def new_task({:mix_task, _task, _args} = mix_task_config, _git_hook_type, _git_hook_args) do
     MixTask.new(mix_task_config)
+  end
+
+  def new_task({_module, _function, _arity} = mfa, git_hook_type, git_hook_args) do
+    MFA.new(mfa, git_hook_type, git_hook_args)
   end
 
   def new_task({_module, _function} = mfa, git_hook_type, git_hook_args) do

--- a/lib/git_hooks.ex
+++ b/lib/git_hooks.ex
@@ -56,7 +56,7 @@ defmodule GitHooks do
     MixTask.new(mix_task_config)
   end
 
-  def new_task({_module, _function, _arity} = mfa, git_hook_type, git_hook_args) do
+  def new_task({_module, _function} = mfa, git_hook_type, git_hook_args) do
     MFA.new(mfa, git_hook_type, git_hook_args)
   end
 

--- a/lib/mix/tasks/git_hooks/run.ex
+++ b/lib/mix/tasks/git_hooks/run.ex
@@ -17,8 +17,6 @@ defmodule Mix.Tasks.GitHooks.Run do
   You can also all the hooks which are configured with `mix git_hooks.run all`.
   """
 
-  @requirements ["app.start"]
-
   use Mix.Task
 
   alias GitHooks.Config

--- a/lib/mix/tasks/git_hooks/run.ex
+++ b/lib/mix/tasks/git_hooks/run.ex
@@ -17,6 +17,8 @@ defmodule Mix.Tasks.GitHooks.Run do
   You can also all the hooks which are configured with `mix git_hooks.run all`.
   """
 
+  @requirements ["app.start"]
+
   use Mix.Task
 
   alias GitHooks.Config

--- a/lib/tasks/mfa.ex
+++ b/lib/tasks/mfa.ex
@@ -42,7 +42,16 @@ defmodule GitHooks.Tasks.MFA do
       %#{__MODULE__}{module: MyModule, function: :my_function, args: ["commit message"]}
 
   """
-  @spec new(mfa(), GitHooks.git_hook_type(), GitHooks.git_hook_args()) :: __MODULE__.t()
+  @spec new(mfa() | {module(), atom()}, GitHooks.git_hook_type(), GitHooks.git_hook_args()) ::
+          __MODULE__.t()
+  def new({module, function, _arity}, _git_hook_type, git_hook_args) do
+    %__MODULE__{
+      module: module,
+      function: function,
+      args: git_hook_args
+    }
+  end
+
   def new({module, function}, _git_hook_type, git_hook_args) do
     %__MODULE__{
       module: module,

--- a/lib/tasks/mfa.ex
+++ b/lib/tasks/mfa.ex
@@ -44,6 +44,7 @@ defmodule GitHooks.Tasks.MFA do
   """
   @spec new(mfa() | {module(), atom()}, GitHooks.git_hook_type(), GitHooks.git_hook_args()) ::
           __MODULE__.t()
+  @deprecated "Use mfa without arity, all functions are expected to have arity 1 and receive a list with the git hook args"
   def new({module, function, _arity}, _git_hook_type, git_hook_args) do
     %__MODULE__{
       module: module,

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,9 @@ defmodule GitHooks.MixProject do
       docs: docs(),
       aliases: aliases(),
       test_coverage: [tool: ExCoveralls],
+      elixirc_options: [
+        warnings_as_errors: false
+      ],
       preferred_cli_env: [
         coveralls: :test,
         "coveralls.detail": :test,
@@ -63,7 +66,6 @@ defmodule GitHooks.MixProject do
 
   defp aliases do
     [
-      compile: ["compile --warnings-as-errors"],
       coveralls: ["coveralls.html"]
     ]
   end

--- a/test/mix/tasks/git_hooks/run_test.exs
+++ b/test/mix/tasks/git_hooks/run_test.exs
@@ -29,28 +29,12 @@ defmodule Mix.Tasks.RunTest do
 
     test "when it is a MFA then the module function it called" do
       put_git_hook_config(:pre_commit,
-        tasks: [{GitHooks.TestSupport.MFADummy, :execute, 0}],
+        tasks: [{GitHooks.TestSupport.MFADummy, :execute}],
         verbose: true
       )
 
       capture_io(fn ->
         assert Run.run(["pre-commit"]) == :ok
-      end)
-    end
-
-    test "when the arity of the MFA is not the same as the git hook raises an error" do
-      put_git_hook_config(:pre_commit,
-        tasks: [{GitHooks.TestSupport.MFATest, :execute, 5}],
-        verbose: true
-      )
-
-      expect_error_message =
-        "Invalid Elixir.GitHooks.TestSupport.MFATest.execute arity for pre_commit, expected 0 but got 5. Check the Git hooks documentation to fix the expected parameters.\n"
-
-      capture_io(fn ->
-        assert_raise RuntimeError, expect_error_message, fn ->
-          Run.run(["pre-commit"])
-        end
       end)
     end
 

--- a/test/mix/tasks/git_hooks/run_test.exs
+++ b/test/mix/tasks/git_hooks/run_test.exs
@@ -38,6 +38,17 @@ defmodule Mix.Tasks.RunTest do
       end)
     end
 
+    test "is backwards compatible with MFA definition including arity" do
+      put_git_hook_config(:pre_commit,
+        tasks: [{GitHooks.TestSupport.MFADummy, :execute, 5}],
+        verbose: true
+      )
+
+      capture_io(fn ->
+        assert Run.run(["pre-commit"]) == :ok
+      end)
+    end
+
     test "when the config is unknown then an error is raised" do
       put_git_hook_config(:pre_commit,
         tasks: [{:cmd, "echo 'test string command'", :make_it_fail}],

--- a/test/support/mfa_dummy.ex
+++ b/test/support/mfa_dummy.ex
@@ -1,5 +1,5 @@
 defmodule GitHooks.TestSupport.MFADummy do
-  def execute() do
+  def execute([]) do
     :ok
   end
 end


### PR DESCRIPTION
This PR basically removes the option to define the MFA arity function, instead it expects all MFA functions to have arity 1.

The reason for that is that git will send dynamic arity for the same hooks depending in the git command arguments you are passing.

For example, for the hook `prepare_commit_msg`, if I run this command: `git commit`, git will send 1 argument to the MFA, in that case I would need to set the MFA with arity 1. But, if I run this command `git commit -am "some message"`, then git will send 2 arguments to the MFA.

And since we can't define 2 arities for the same MFA, this breaks the current logic.

Removing the arity option and expecting arity 1 always solves the issue since the MFA will always receive a list of arguments.

So, for the above case, I could implement the MFA function using pattern match for each arity expected like this:

```elixir
def run([arg1, arg2]), do: ...
def run([arg1], do: ...
```

Or, do something like this if you are only interested in the first argument (like I do):

```elixir
def run([commit_msg_file | _]), do: ...
```