### PR TITLE
Add support for pre-merge-commit

### DIFF
--- a/lib/config.ex
+++ b/lib/config.ex
@@ -17,6 +17,7 @@ defmodule GitHooks.Config do
     :pre_receive,
     :post_receive,
     :post_checkout,
+    :pre_merge_commit,
     :post_merge,
     :pre_push,
     :push_to_checkout,


### PR DESCRIPTION
Adds support for the [pre-merge-commit](https://git-scm.com/docs/githooks#_pre_merge_commit) hook, which gets triggered from `git merge`.

Not sure if specific tests are needed since it doesn't look like there's ones for other hooks, but happy to add if needed.