### PR TITLE
Add more example for mix tasks config

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ config :git_hooks,
     commit_msg: [
       tasks: [
         {:mix_task, :test},
+        {:mix_task, :"hex.user", "whoami"},
         {:mix_task, :format, ["--dry-run"]}
       ]
     ]

--- a/lib/config/verbose_config.ex
+++ b/lib/config/verbose_config.ex
@@ -16,6 +16,14 @@ defmodule GitHooks.Config.VerboseConfig do
   general one.
   """
   @spec verbose?(atom) :: boolean()
+  def verbose?("all") do
+    Application.get_env(:git_hooks, :verbose, false)
+  end
+
+  def verbose?(:all) do
+    Application.get_env(:git_hooks, :verbose, false)
+  end
+
   def verbose?(git_hook_type) do
     git_hook_type
     |> Config.get_git_hook_type_config()

--- a/lib/tasks/cmd.ex
+++ b/lib/tasks/cmd.ex
@@ -59,20 +59,22 @@ defmodule GitHooks.Tasks.Cmd do
         ) ::
           __MODULE__.t()
   def new({:cmd, original_command, opts}, git_hook_type, git_hook_args) when is_list(opts) do
-    [base_command | args] = String.split(original_command, " ")
+    env_vars = Keyword.get(opts, :env, [])
+    include_hook_args = Keyword.get(opts, :include_hook_args, false)
 
-    command_args =
-      if Keyword.get(opts, :include_hook_args, false) do
-        Enum.concat(args, git_hook_args)
+    cmd_string =
+      if include_hook_args do
+        original_command <> " " <> Enum.join(git_hook_args, " ")
       else
-        args
+        original_command
       end
 
     %__MODULE__{
       original_command: original_command,
-      command: base_command,
-      args: command_args,
-      env: Keyword.get(opts, :env, []),
+      command: "sh",
+      # ["-c", "full shell command"]
+      args: ["-c", cmd_string],
+      env: env_vars,
       git_hook_type: git_hook_type
     }
   end

--- a/lib/tasks/cmd.ex
+++ b/lib/tasks/cmd.ex
@@ -46,10 +46,10 @@ defmodule GitHooks.Tasks.Cmd do
   ### Examples
 
       iex> #{__MODULE__}.new({:cmd, "ls -l", env: [{"var", "test"}], include_hook_args: true}, :pre_commit, ["commit message"])
-      %#{__MODULE__}{command: "ls", original_command: "ls -l", args: ["-l", "commit message"], env: [{"var", "test"}], git_hook_type: :pre_commit}
+      %#{__MODULE__}{command: "sh", original_command: "ls -l", args: ["-c", "ls -l commit message"], env: [{"var", "test"}], git_hook_type: :pre_commit}
 
       iex> #{__MODULE__}.new({:cmd, "ls", include_hook_args: false}, :pre_commit, ["commit message"])
-      %#{__MODULE__}{command: "ls", original_command: "ls", args: [], env: [], git_hook_type: :pre_commit}
+      %#{__MODULE__}{command: "sh", original_command: "ls", args: ["-c", "ls"], env: [], git_hook_type: :pre_commit}
 
   """
   @spec new(


### PR DESCRIPTION
This PR fixes an issue where commands chained with shell operators like `&&` or `||` were not executed correctly. 

The problem was caused by splitting the command string with `String.split(original_command, " ")`, which treated operators as arguments.


To fix this issue, the command is now passed directly to the shell for execution, allowing proper handling of shell operators.

Solves the error reported in #150 