### PR TITLE
Guard installs when hooks path is external

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -42,93 +42,87 @@
       # You can customize the parameters of any check by adding a second element
       # to the tuple.
       #
-      # To disable a check put `false` as second element:
+      # Move checks that should not run to the `disabled` list.
       #
-      #     {Credo.Check.Design.DuplicatedCode, false}
-      #
-      checks: [
-        {Credo.Check.Readability.ModuleDoc},
-        {Credo.Check.Consistency.ExceptionNames},
-        {Credo.Check.Consistency.LineEndings},
-        {Credo.Check.Consistency.ParameterPatternMatching},
-        {Credo.Check.Consistency.SpaceAroundOperators},
-        {Credo.Check.Consistency.SpaceInParentheses},
-        {Credo.Check.Consistency.TabsOrSpaces},
+      checks: %{
+        enabled: [
+          {Credo.Check.Readability.ModuleDoc},
+          {Credo.Check.Consistency.ExceptionNames},
+          {Credo.Check.Consistency.LineEndings},
+          {Credo.Check.Consistency.ParameterPatternMatching},
+          {Credo.Check.Consistency.SpaceAroundOperators},
+          {Credo.Check.Consistency.SpaceInParentheses},
+          {Credo.Check.Consistency.TabsOrSpaces},
 
-        # For some checks, like AliasUsage, you can only customize the priority
-        # Priority values are: `low, normal, high, higher`
-        {Credo.Check.Design.AliasUsage, priority: :low},
+          # For some checks, like AliasUsage, you can only customize the priority
+          # Priority values are: `low, normal, high, higher`
+          {Credo.Check.Design.AliasUsage, priority: :low},
 
-        # For others you can set parameters
+          # For others you can set parameters
 
-        # If you don't want the `setup` and `test` macro calls in ExUnit tests
-        # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
-        # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
-        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+          # If you don't want the `setup` and `test` macro calls in ExUnit tests
+          # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
+          # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
+          {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
 
-        # You can also customize the exit_status of each check.
-        # If you don't want TODO comments to cause `mix credo` to fail, just
-        # set this value to 0 (zero).
-        {Credo.Check.Design.TagTODO, exit_status: 2},
-        {Credo.Check.Design.TagFIXME},
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          {Credo.Check.Design.TagTODO, exit_status: 2},
+          {Credo.Check.Design.TagFIXME},
+          {Credo.Check.Readability.FunctionNames},
+          {Credo.Check.Readability.LargeNumbers},
+          {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 150},
+          {Credo.Check.Readability.ModuleAttributeNames},
+          {Credo.Check.Readability.ModuleNames},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
+          {Credo.Check.Readability.ParenthesesInCondition},
+          {Credo.Check.Readability.PredicateFunctionNames},
+          {Credo.Check.Readability.PreferImplicitTry},
+          {Credo.Check.Readability.RedundantBlankLines},
+          {Credo.Check.Readability.StringSigils},
+          {Credo.Check.Readability.TrailingBlankLine},
+          {Credo.Check.Readability.TrailingWhiteSpace},
+          {Credo.Check.Readability.VariableNames},
+          {Credo.Check.Readability.Semicolons},
+          {Credo.Check.Readability.SpaceAfterCommas},
+          {Credo.Check.Refactor.DoubleBooleanNegation},
+          {Credo.Check.Refactor.CondStatements},
+          {Credo.Check.Refactor.CyclomaticComplexity},
+          {Credo.Check.Refactor.FunctionArity},
+          {Credo.Check.Refactor.MatchInCondition},
+          {Credo.Check.Refactor.NegatedConditionsInUnless},
+          {Credo.Check.Refactor.NegatedConditionsWithElse},
+          {Credo.Check.Refactor.Nesting, max_nesting: 3},
+          {Credo.Check.Refactor.PipeChainStart},
+          {Credo.Check.Refactor.UnlessWithElse},
+          {Credo.Check.Warning.BoolOperationOnSameValues},
+          {Credo.Check.Warning.IExPry},
+          {Credo.Check.Warning.IoInspect},
+          {Credo.Check.Warning.OperationOnSameValues},
+          {Credo.Check.Warning.OperationWithConstantResult},
+          {Credo.Check.Warning.UnusedEnumOperation},
+          {Credo.Check.Warning.UnusedFileOperation},
+          {Credo.Check.Warning.UnusedKeywordOperation},
+          {Credo.Check.Warning.UnusedListOperation},
+          {Credo.Check.Warning.UnusedPathOperation},
+          {Credo.Check.Warning.UnusedRegexOperation},
+          {Credo.Check.Warning.UnusedStringOperation},
+          {Credo.Check.Warning.UnusedTupleOperation}
+        ],
+        disabled: [
+          # Controversial and experimental checks
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
 
-        {Credo.Check.Readability.FunctionNames},
-        {Credo.Check.Readability.LargeNumbers},
-        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 150},
-        {Credo.Check.Readability.ModuleAttributeNames},
-        {Credo.Check.Readability.ModuleNames},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
-        {Credo.Check.Readability.ParenthesesInCondition},
-        {Credo.Check.Readability.PredicateFunctionNames},
-        {Credo.Check.Readability.PreferImplicitTry},
-        {Credo.Check.Readability.RedundantBlankLines},
-        {Credo.Check.Readability.StringSigils},
-        {Credo.Check.Readability.TrailingBlankLine},
-        {Credo.Check.Readability.TrailingWhiteSpace},
-        {Credo.Check.Readability.VariableNames},
-        {Credo.Check.Readability.Semicolons},
-        {Credo.Check.Readability.SpaceAfterCommas},
-
-        {Credo.Check.Refactor.DoubleBooleanNegation},
-        {Credo.Check.Refactor.CondStatements},
-        {Credo.Check.Refactor.CyclomaticComplexity},
-        {Credo.Check.Refactor.FunctionArity},
-        {Credo.Check.Refactor.MatchInCondition},
-        {Credo.Check.Refactor.NegatedConditionsInUnless},
-        {Credo.Check.Refactor.NegatedConditionsWithElse},
-        {Credo.Check.Refactor.Nesting, max_nesting: 3},
-        {Credo.Check.Refactor.PipeChainStart},
-        {Credo.Check.Refactor.UnlessWithElse},
-
-        {Credo.Check.Warning.BoolOperationOnSameValues},
-        {Credo.Check.Warning.IExPry},
-        {Credo.Check.Warning.IoInspect},
-        {Credo.Check.Warning.LazyLogging},
-        {Credo.Check.Warning.OperationOnSameValues},
-        {Credo.Check.Warning.OperationWithConstantResult},
-        {Credo.Check.Warning.UnusedEnumOperation},
-        {Credo.Check.Warning.UnusedFileOperation},
-        {Credo.Check.Warning.UnusedKeywordOperation},
-        {Credo.Check.Warning.UnusedListOperation},
-        {Credo.Check.Warning.UnusedPathOperation},
-        {Credo.Check.Warning.UnusedRegexOperation},
-        {Credo.Check.Warning.UnusedStringOperation},
-        {Credo.Check.Warning.UnusedTupleOperation},
-
-        # Controversial and experimental checks (opt-in, just remove `, false`)
-        #
-        {Credo.Check.Refactor.ABCSize, false},
-        {Credo.Check.Refactor.AppendSingleItem, false},
-        {Credo.Check.Refactor.VariableRebinding, false},
-        {Credo.Check.Warning.MapGetUnsafePass, false},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
-
-        # Deprecated checks (these will be deleted after a grace period)
-        {Credo.Check.Readability.Specs, false},
-
-        # Custom checks can be created using `mix credo.gen.check`.
-        #
-      ]
+          # Incompatible or deprecated checks
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Warning.LazyLogging, []}
+        ]
+      }
     }
   ]
 }

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter,.credo}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ mix git_hooks.install
 To disable the automatic install of the git hooks set the configuration key `auto_install` to
 `false`.
 
+### External hooks path
+
+If `core.hooksPath` resolves outside both the repository and its Git directory (for example, to a
+global hooks directory), `git_hooks` will refuse to install by default to avoid overwriting shared
+hooks. The default hooks directories used by linked worktrees and submodules are inside their
+common Git directories, so they remain allowed. To override the guard for another external path,
+set `allow_external_hooks_path: true` or export `GIT_HOOKS_ALLOW_EXTERNAL=1`.
+
 ### Hook configuration
 
 One or more git hooks can be configured, those hooks will be the ones
@@ -129,6 +137,9 @@ Setting a custom _git hooks_ config path is also supported:
 ```
 git config core.hooksPath .myCustomGithooks/
 ```
+
+If the configured hooks path points outside the repository, set
+`allow_external_hooks_path: true` (or `GIT_HOOKS_ALLOW_EXTERNAL=1`) to allow installation.
 
 ### Custom project path
 

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -75,6 +75,14 @@ defmodule GitHooks.Config do
     Application.get_env(:git_hooks, :extra_success_returns, [])
   end
 
+  @doc """
+  Returns whether installs are allowed when the resolved hooks path is outside the repo.
+  """
+  @spec allow_external_hooks_path?() :: boolean
+  def allow_external_hooks_path? do
+    Application.get_env(:git_hooks, :allow_external_hooks_path, false)
+  end
+
   defdelegate tasks(git_hook_type), to: TasksConfig
 
   defdelegate verbose?, to: VerboseConfig

--- a/lib/git/git_path.ex
+++ b/lib/git/git_path.ex
@@ -28,6 +28,21 @@ defmodule GitHooks.Git.GitPath do
   end
 
   @doc """
+  Returns the absolute path to the common Git directory.
+
+  For linked worktrees and submodules, this is the Git directory that contains
+  the shared hooks directory.
+  """
+  def resolve_git_common_dir do
+    {git_common_dir, 0} =
+      System.cmd("git", ["rev-parse", "--git-common-dir"], cd: resolve_app_path())
+
+    git_common_dir
+    |> String.trim()
+    |> Path.expand(resolve_app_path())
+  end
+
+  @doc """
   Returns the path to a specific hook file within the `.git/hooks` directory.
   """
   def git_hooks_path_for(hook_name) do

--- a/lib/mix/tasks/git_hooks/install.ex
+++ b/lib/mix/tasks/git_hooks/install.ex
@@ -37,6 +37,19 @@ defmodule Mix.Tasks.GitHooks.Install do
 
   @spec install(Keyword.t()) :: any()
   defp install(opts) do
+    if external_hooks_path?() && !allow_external_hooks_path?() do
+      Printer.warn("""
+      Refusing to install git hooks outside the repository.
+      Set a repo-local core.hooksPath or configure allow_external_hooks_path: true (or GIT_HOOKS_ALLOW_EXTERNAL=1) to override.
+      """)
+
+      if opts[:dry_run], do: [], else: :ok
+    else
+      do_install(opts)
+    end
+  end
+
+  defp do_install(opts) do
     template_file =
       :git_hooks
       |> :code.priv_dir()
@@ -183,6 +196,30 @@ defmodule Mix.Tasks.GitHooks.Install do
     case File.rename(backup_path, restore_path) do
       :ok -> :ok
       {:error, reason} -> Printer.warn("Cannot restore backup: #{inspect(reason)}")
+    end
+  end
+
+  defp external_hooks_path? do
+    hooks_path = GitPath.resolve_git_hooks_path()
+
+    [GitPath.resolve_app_path(), GitPath.resolve_git_common_dir()]
+    |> Enum.all?(fn trusted_path -> !path_within?(hooks_path, trusted_path) end)
+  end
+
+  defp path_within?(path, parent) do
+    relative_path = Path.relative_to(path, parent)
+
+    Path.type(relative_path) == :relative && List.first(Path.split(relative_path)) != ".."
+  end
+
+  defp allow_external_hooks_path? do
+    Config.allow_external_hooks_path?() || truthy_env?("GIT_HOOKS_ALLOW_EXTERNAL")
+  end
+
+  defp truthy_env?(key) do
+    case System.get_env(key) do
+      nil -> false
+      value -> String.downcase(value) in ["1", "true", "yes"]
     end
   end
 end

--- a/lib/tasks/cmd.ex
+++ b/lib/tasks/cmd.ex
@@ -82,8 +82,8 @@ end
 
 defimpl GitHooks.Task, for: GitHooks.Tasks.Cmd do
   alias GitHooks.Config
-  alias GitHooks.Tasks.Cmd
   alias GitHooks.Printer
+  alias GitHooks.Tasks.Cmd
 
   def run(%Cmd{command: command, args: args, env: env, git_hook_type: git_hook_type} = cmd, _opts) do
     result =

--- a/lib/tasks/file.ex
+++ b/lib/tasks/file.ex
@@ -79,8 +79,8 @@ end
 
 defimpl GitHooks.Task, for: GitHooks.Tasks.File do
   alias GitHooks.Config
-  alias GitHooks.Tasks.File
   alias GitHooks.Printer
+  alias GitHooks.Tasks.File
 
   def run(
         %File{file_path: script_file, env: env, args: args, git_hook_type: git_hook_type} = file,

--- a/lib/tasks/mfa.ex
+++ b/lib/tasks/mfa.ex
@@ -62,8 +62,8 @@ defmodule GitHooks.Tasks.MFA do
 end
 
 defimpl GitHooks.Task, for: GitHooks.Tasks.MFA do
-  alias GitHooks.Tasks.MFA
   alias GitHooks.Printer
+  alias GitHooks.Tasks.MFA
 
   # Kernel.apply will throw a error if something fails
   def run(%MFA{} = mfa, opts, second_run? \\ false) do

--- a/lib/tasks/mix.ex
+++ b/lib/tasks/mix.ex
@@ -53,8 +53,8 @@ defmodule GitHooks.Tasks.Mix do
 end
 
 defimpl GitHooks.Task, for: GitHooks.Tasks.Mix do
-  alias GitHooks.Tasks.Mix, as: MixTask
   alias GitHooks.Printer
+  alias GitHooks.Tasks.Mix, as: MixTask
 
   # Mix tasks raise an error if they are valid, but determining if they are
   # success or not depends on the return of the task.

--- a/test/git/path_test.exs
+++ b/test/git/path_test.exs
@@ -4,7 +4,7 @@ defmodule GitHooks.Git.PathTest do
 
   alias GitHooks.Git.GitPath
 
-  @tag capture_log: true
+  @moduletag capture_log: true
 
   describe "git_hooks_path_for/1" do
     test "appends the path to the `.git/hooks` folder", %{tmp_dir: project_path} do
@@ -15,6 +15,12 @@ defmodule GitHooks.Git.PathTest do
   describe "resolve_git_hooks_path/0" do
     test "returns the git path of the project", %{tmp_dir: project_path} do
       assert GitPath.resolve_git_hooks_path() == "#{project_path}/.git/hooks"
+    end
+  end
+
+  describe "resolve_git_common_dir/0" do
+    test "returns the common Git directory", %{tmp_dir: project_path} do
+      assert GitPath.resolve_git_common_dir() == "#{project_path}/.git"
     end
   end
 

--- a/test/mix/tasks/git_hooks/install_test.exs
+++ b/test/mix/tasks/git_hooks/install_test.exs
@@ -5,9 +5,26 @@ defmodule Mix.Tasks.InstallTest do
   use GitHooks.TestSupport.ConfigCase
   use GitHooks.TestSupport.GitProjectCase
 
+  import ExUnit.CaptureIO
+
   alias Mix.Tasks.GitHooks.Install
 
-  @tag capture_log: true
+  @moduletag capture_log: true
+
+  setup do
+    external_override = System.get_env("GIT_HOOKS_ALLOW_EXTERNAL")
+    System.delete_env("GIT_HOOKS_ALLOW_EXTERNAL")
+
+    on_exit(fn ->
+      if external_override do
+        System.put_env("GIT_HOOKS_ALLOW_EXTERNAL", external_override)
+      else
+        System.delete_env("GIT_HOOKS_ALLOW_EXTERNAL")
+      end
+    end)
+
+    :ok
+  end
 
   describe "run/1" do
     test "replaces the hook template with config values", %{tmp_dir: project_path} do
@@ -32,7 +49,7 @@ defmodule Mix.Tasks.InstallTest do
 
       custom_path = Path.join(project_path, "a_custom_path")
       File.mkdir_p!(custom_path)
-      System.cmd("git", ["init"], cd: custom_path)
+      System.cmd("git", ["-c", "init.defaultBranch=master", "init", "--quiet"], cd: custom_path)
       Application.put_env(:git_hooks, :project_path, custom_path)
 
       hooks_file = Install.run(["--dry-run", "--quiet"])
@@ -86,6 +103,155 @@ defmodule Mix.Tasks.InstallTest do
                ]
       end)
     end
+
+    test "refuses to install when hooks path is outside the repo", %{tmp_dir: project_path} do
+      put_git_hook_config(
+        [:pre_commit, :pre_push],
+        tasks: {:cmd, "check"}
+      )
+
+      external_hooks_dir = configure_external_hooks_path(project_path)
+      existing_hook = Path.join(external_hooks_dir, "pre-commit")
+      File.write!(existing_hook, "existing shared hook")
+
+      output =
+        capture_io(fn ->
+          assert Install.run(["--quiet"]) == :ok
+        end)
+
+      assert output =~ "Refusing to install git hooks outside the repository."
+      assert File.read!(existing_hook) == "existing shared hook"
+      refute File.exists?(Path.join(external_hooks_dir, "pre-push"))
+      refute File.exists?(Path.join(external_hooks_dir, "git_hooks.db"))
+    end
+
+    test "allows install when hooks path is outside the repo with explicit opt-in", %{
+      tmp_dir: project_path
+    } do
+      put_git_hook_config(
+        [:pre_commit, :pre_push],
+        tasks: {:cmd, "check"}
+      )
+
+      external_hooks_dir = configure_external_hooks_path(project_path)
+      Application.put_env(:git_hooks, :allow_external_hooks_path, true)
+
+      assert Install.run(["--quiet"]) == :ok
+
+      assert File.read!(Path.join(external_hooks_dir, "pre-commit")) ==
+               expect_hook_template("pre_commit", project_path)
+
+      assert File.read!(Path.join(external_hooks_dir, "pre-push")) ==
+               expect_hook_template("pre_push", project_path)
+    end
+
+    test "allows install when the environment opts into an external hooks path", %{
+      tmp_dir: project_path
+    } do
+      put_git_hook_config(
+        [:pre_commit, :pre_push],
+        tasks: {:cmd, "check"}
+      )
+
+      configure_external_hooks_path(project_path)
+      System.put_env("GIT_HOOKS_ALLOW_EXTERNAL", "yes")
+
+      hooks_file = Install.run(["--dry-run", "--quiet"])
+
+      assert hooks_file == [
+               pre_commit: expect_hook_template("pre_commit", project_path),
+               pre_push: expect_hook_template("pre_push", project_path)
+             ]
+    end
+
+    test "allows the shared hooks directory from a linked worktree", %{tmp_dir: project_path} do
+      put_git_hook_config(
+        [:pre_commit, :pre_push],
+        tasks: {:cmd, "check"}
+      )
+
+      File.write!(Path.join(project_path, "README.md"), "test repository")
+      git!(project_path, ["add", "README.md"])
+
+      git!(project_path, [
+        "-c",
+        "user.name=Git Hooks Test",
+        "-c",
+        "user.email=git-hooks@example.com",
+        "commit",
+        "--quiet",
+        "-m",
+        "Initial commit"
+      ])
+
+      worktree_path = unique_tmp_path("git_hooks_worktree")
+      on_exit(fn -> File.rm_rf(worktree_path) end)
+
+      git!(project_path, [
+        "worktree",
+        "add",
+        "--quiet",
+        "-b",
+        "linked-worktree",
+        worktree_path
+      ])
+
+      Application.put_env(:git_hooks, :project_path, worktree_path)
+
+      hooks_file = Install.run(["--dry-run", "--quiet"])
+
+      assert hooks_file == [
+               pre_commit: expect_hook_template("pre_commit", worktree_path),
+               pre_push: expect_hook_template("pre_push", worktree_path)
+             ]
+    end
+
+    test "allows the Git hooks directory for a submodule", %{tmp_dir: project_path} do
+      put_git_hook_config(
+        [:pre_commit, :pre_push],
+        tasks: {:cmd, "check"}
+      )
+
+      source_path = unique_tmp_path("git_hooks_submodule_source")
+      File.mkdir_p!(source_path)
+      on_exit(fn -> File.rm_rf(source_path) end)
+
+      git!(source_path, ["-c", "init.defaultBranch=master", "init", "--quiet"])
+      File.write!(Path.join(source_path, "README.md"), "test submodule")
+      git!(source_path, ["add", "README.md"])
+
+      git!(source_path, [
+        "-c",
+        "user.name=Git Hooks Test",
+        "-c",
+        "user.email=git-hooks@example.com",
+        "commit",
+        "--quiet",
+        "-m",
+        "Initial commit"
+      ])
+
+      submodule_path = Path.join(project_path, "submodule")
+
+      git!(project_path, [
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "--quiet",
+        source_path,
+        submodule_path
+      ])
+
+      Application.put_env(:git_hooks, :project_path, submodule_path)
+
+      hooks_file = Install.run(["--dry-run", "--quiet"])
+
+      assert hooks_file == [
+               pre_commit: expect_hook_template("pre_commit", submodule_path),
+               pre_push: expect_hook_template("pre_push", submodule_path)
+             ]
+    end
   end
 
   #
@@ -101,5 +267,28 @@ mix git_hooks.run #{git_hook} "$@"
 [ $? -ne 0 ] && exit 1
 exit 0
 )
+  end
+
+  defp configure_external_hooks_path(project_path) do
+    external_hooks_dir = unique_tmp_path("git_hooks_external")
+    File.mkdir_p!(external_hooks_dir)
+    on_exit(fn -> File.rm_rf(external_hooks_dir) end)
+
+    git!(project_path, ["config", "core.hooksPath", external_hooks_dir])
+
+    external_hooks_dir
+  end
+
+  defp git!(project_path, args) do
+    {output, exit_status} =
+      System.cmd("git", args, cd: project_path, stderr_to_stdout: true)
+
+    assert exit_status == 0, output
+
+    String.trim(output)
+  end
+
+  defp unique_tmp_path(prefix) do
+    Path.join(System.tmp_dir!(), "#{prefix}_#{System.unique_integer([:positive])}")
   end
 end

--- a/test/mix/tasks/git_hooks/run_test.exs
+++ b/test/mix/tasks/git_hooks/run_test.exs
@@ -10,6 +10,11 @@ defmodule Mix.Tasks.RunTest do
 
   alias Mix.Tasks.GitHooks.Run
 
+  setup do
+    Application.put_env(:git_hooks, :current_branch_fn, fn -> {"master\n", 0} end)
+    on_exit(fn -> Application.delete_env(:git_hooks, :current_branch_fn) end)
+  end
+
   describe "Given task" do
     test "when it is a file then the file it's executed" do
       put_git_hook_config(:pre_commit, tasks: [{:file, "priv/test_script"}], verbose: true)

--- a/test/support/config_case.ex
+++ b/test/support/config_case.ex
@@ -26,6 +26,7 @@ defmodule GitHooks.TestSupport.ConfigCase do
       def cleanup_config do
         Application.delete_env(:git_hooks, :hooks)
         Application.delete_env(:git_hooks, :verbose)
+        Application.delete_env(:git_hooks, :allow_external_hooks_path)
       end
 
       @spec put_git_hook_config(list(atom) | atom, keyword) :: :ok

--- a/test/support/git_project_case.ex
+++ b/test/support/git_project_case.ex
@@ -12,7 +12,7 @@ defmodule GitHooks.TestSupport.GitProjectCase do
         tmp_dir = Path.join(System.tmp_dir!(), "git_hooks_test_#{:os.system_time(:millisecond)}")
         File.mkdir_p!(tmp_dir)
 
-        System.cmd("git", ["init"], cd: tmp_dir)
+        System.cmd("git", ["-c", "init.defaultBranch=master", "init", "--quiet"], cd: tmp_dir)
 
         Application.put_env(:git_hooks, :project_path, tmp_dir)
 


### PR DESCRIPTION
## Summary
- Skip installation when the resolved hooks path is outside the repo unless explicitly allowed.
- Add `allow_external_hooks_path` config + `GIT_HOOKS_ALLOW_EXTERNAL` env override.
- Add install tests for external hooks path + opt-in.
- Keep tests warning-free by avoiding deprecated MFA.new/3 in core code and silencing git init hints.

## Testing
- mix test