### PR TITLE
Fix compilation warnings on Elixir 1.20 / OTP 29

### DIFF
--- a/lib/git_hooks.ex
+++ b/lib/git_hooks.ex
@@ -57,8 +57,8 @@ defmodule GitHooks do
     MixTask.new(mix_task_config)
   end
 
-  def new_task({_module, _function, _arity} = mfa, git_hook_type, git_hook_args) do
-    MFA.new(mfa, git_hook_type, git_hook_args)
+  def new_task({module, function, _arity}, git_hook_type, git_hook_args) do
+    MFA.new({module, function}, git_hook_type, git_hook_args)
   end
 
   def new_task({_module, _function} = mfa, git_hook_type, git_hook_args) do

--- a/lib/mix/tasks/git_hooks/run.ex
+++ b/lib/mix/tasks/git_hooks/run.ex
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.GitHooks.Run do
   defp run_task(task_config, git_hook_type, git_hook_args) do
     task_config
     |> GitHooks.new_task(git_hook_type, git_hook_args)
-    |> GitHooks.Task.run()
+    |> GitHooks.Task.run([])
     |> GitHooks.Task.print_result()
     |> GitHooks.Task.success?()
     |> exit_if_failed()

--- a/lib/task.ex
+++ b/lib/task.ex
@@ -15,7 +15,7 @@ defprotocol GitHooks.Task do
   @doc """
   Runs the task.
   """
-  def run(task, opts \\ [])
+  def run(task, opts)
 
   @spec print_result(t()) :: task :: term
   @doc """

--- a/lib/tasks/mfa.ex
+++ b/lib/tasks/mfa.ex
@@ -44,7 +44,6 @@ defmodule GitHooks.Tasks.MFA do
   """
   @spec new(mfa() | {module(), atom()}, GitHooks.git_hook_type(), GitHooks.git_hook_args()) ::
           __MODULE__.t()
-  @deprecated "Use mfa without arity, all functions are expected to have arity 1 and receive a list with the git hook args"
   def new({module, function, _arity}, _git_hook_type, git_hook_args) do
     %__MODULE__{
       module: module,

--- a/mix.exs
+++ b/mix.exs
@@ -21,12 +21,7 @@ defmodule GitHooks.MixProject do
       elixirc_options: [
         warnings_as_errors: false
       ],
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.post": :test,
-        "coveralls.html": :test
-      ],
+
       dialyzer: [plt_add_deps: :app_tree, plt_add_apps: [:mix]]
     ]
   end
@@ -61,6 +56,17 @@ defmodule GitHooks.MixProject do
       {:excoveralls, "~> 0.10", only: :test},
       {:inch_ex, ">= 0.0.0", only: :docs},
       {:recase, "~> 0.8.0"}
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
+      ]
     ]
   end
 


### PR DESCRIPTION
Hey @qgadrian, thanks for maintaining this great library!

These changes resolve all compilation warnings when building on Elixir 1.20.1 / OTP 29:

- Move `preferred_cli_env` from `def project` to `def cli` (deprecated in Mix 1.20)
- Remove default argument from protocol `def run/2` (deprecated in Elixir 1.20)
- Drop `@deprecated` on `MFA.new/3` — the 2-tuple clause is the intended API; deprecating the whole function also warns for valid callers
- Convert 3-tuple mfa to 2-tuple before passing to `MFA.new`
- Add explicit `[]` arg to `GitHooks.Task.run` call

If this looks good, would you also consider cutting a new release so downstream projects can pick it up? No rush — appreciate your time either way.